### PR TITLE
ddskkの設定改善

### DIFF
--- a/.emacs.d/inits/00-skk.el
+++ b/.emacs.d/inits/00-skk.el
@@ -1,9 +1,3 @@
-;; AquaSKK setting
-(if (eq system-type 'darwin)
-    (setq skk-server-portnum 1178))
-(if (eq system-type 'darwin)
-    (setq skk-server-host "localhost"))
-
 ;; ddskk
 (setq-default skk-user-directory "~/.ddskk")
 

--- a/.emacs.d/inits/00-skk.el
+++ b/.emacs.d/inits/00-skk.el
@@ -6,8 +6,8 @@
 
 ;; ddskk
 (setq-default skk-user-directory "~/.ddskk")
-(el-get-bundle ddskk
-  (global-set-key (kbd "C-j") 'skk-mode))
+(el-get-bundle ddskk)
+(global-set-key (kbd "C-j") 'skk-mode)
 
 (setq-default dired-bind-jump nil)
 (add-hook 'isearch-mode-hook

--- a/.emacs.d/inits/00-skk.el
+++ b/.emacs.d/inits/00-skk.el
@@ -6,8 +6,19 @@
 
 ;; ddskk
 (setq-default skk-user-directory "~/.ddskk")
+
 (el-get-bundle ddskk)
 (global-set-key (kbd "C-j") 'skk-mode)
+
+;; 文章系のバッファを開いた時には自動的に英数モード(「SKK」モード)に入る
+(let ((function #'(lambda ()
+		    (require 'skk)
+		    (skk-latin-mode-on))))
+  (dolist (hook '(find-file-hooks
+		  ;; ...
+		  mail-setup-hook
+		  message-setup-hook))
+    (add-hook hook function)))
 
 (setq-default dired-bind-jump nil)
 (add-hook 'isearch-mode-hook


### PR DESCRIPTION
# 改善したこと
- 文書系のバッファを開いたときに自動的に英数モードに入るようにしたので、いちいちskk-modeのコマンドを実行しなくて済むようになった
# まだ直っていないこと
- AquaSKKに関する設定を消したので、OSのインプットメソッドの辞書との共有化ができていないこと
  - 元々できていなかった
# 他改善できること

http://openlab.ring.gr.jp/skk/skk/main/etc/dot.emacs や http://openlab.ring.gr.jp/skk/skk/main/etc/dot.skk を見ながら探す。
## AquaSKKやMacについて

http://openlab.ring.gr.jp/skk/skk/main/READMEs/README.MacOSX.ja を見る
