### PR TITLE
flycheckの設定改善

### DIFF
--- a/.emacs.d/inits/30-flycheck.el
+++ b/.emacs.d/inits/30-flycheck.el
@@ -2,5 +2,5 @@
 ;; @ flycheck
 ;; modern on-the-fly syntax checking extension.
 ;; https://github.com/flycheck/flycheck
-(el-get-bundle flycheck
-  (add-hook 'after-init-hook #'global-flycheck-mode))
+(el-get-bundle flycheck)
+(add-hook 'after-init-hook #'global-flycheck-mode)

--- a/.emacs.d/inits/30-flycheck.el
+++ b/.emacs.d/inits/30-flycheck.el
@@ -3,4 +3,6 @@
 ;; modern on-the-fly syntax checking extension.
 ;; https://github.com/flycheck/flycheck
 (el-get-bundle flycheck)
+
 (add-hook 'after-init-hook #'global-flycheck-mode)
+(setq-default flycheck-disabled-checkers '(emacs-lisp-checkdoc))


### PR DESCRIPTION
# 改善したこと
- elispのドキュメントコメントでエラーが出なくなった
# まだ直っていないこと
- elispで変数が `reference to free variable` とエラーが出ることがある
- 各言語毎で意図しないエラーが起こる
  - 言語毎の設定で対応する
  - 30-fly-check.el のファイルには、fly-check自体の設定を書く
# 他改善出来そうなこと

特になし?
