### PR TITLE
Perlの設定改善 close #9

### DIFF
--- a/.emacs.d/inits/30-yasnippet.el
+++ b/.emacs.d/inits/30-yasnippet.el
@@ -1,0 +1,6 @@
+(el-get-bundle! yasnippet)
+
+(setq yas-snippet-dirs
+      (list
+       (locate-user-emacs-file "snippets")))
+(yas-global-mode 1)

--- a/.emacs.d/inits/40-perl.el
+++ b/.emacs.d/inits/40-perl.el
@@ -23,3 +23,21 @@
              (progn
                (setq indent-tabs-mode nil)
                (setq tab-width nil))))
+
+;; flycheck settings
+(flycheck-define-checker perl-project-libs
+  "A perl syntac checker."
+  :command ("perl"
+            "-MProject::Libs lib_dirs => [qw(local/lib/perl5)]"
+            "-wc"
+            source-inplace)
+  :error-patterns ((error line-start
+                          (minimal-match (message))
+                          " at " (file-name) " line " line
+                          (or "." (and "," (zero-or-more not-newline)))
+                          line-end))
+  :modes (cperl-mode))
+(add-hook 'cperl-mode-hook
+          (lambda ()
+            (flycheck-mode t)
+            (setq flycheck-checker 'perl-project-libs)))

--- a/.emacs.d/inits/40-perl.el
+++ b/.emacs.d/inits/40-perl.el
@@ -25,19 +25,28 @@
                (setq tab-width nil))))
 
 ;; flycheck settings
-(flycheck-define-checker perl-project-libs
-  "A perl syntac checker."
-  :command ("perl"
-            "-MProject::Libs lib_dirs => [qw(local/lib/perl5)]"
-            "-wc"
-            source-inplace)
-  :error-patterns ((error line-start
-                          (minimal-match (message))
-                          " at " (file-name) " line " line
-                          (or "." (and "," (zero-or-more not-newline)))
-                          line-end))
-  :modes (cperl-mode))
-(add-hook 'cperl-mode-hook
-          (lambda ()
-            (flycheck-mode t)
-            (setq flycheck-checker 'perl-project-libs)))
+
+;; disable my module error
+;; http://m0t0k1ch1st0ry.com/blog/2014/07/07/flycheck/
+;; (flycheck-define-checker perl-project-libs
+;;   "A perl syntax checker."
+;;   :command ("perl"
+;;             "-MProject::Libs lib_dirs => [qw(local/lib/perl5)]"
+;;             "-wc"
+;;             source-inplace)
+;;   :error-patterns ((error line-start
+;;                           (minimal-match (message))
+;;                           " at " (file-name) " line " line
+;;                           (or "." (and ", " (zero-or-more not-newline)))
+;;                           line-end))
+;;   :modes (cperl-mode))
+;; (add-hook 'cperl-mode-hook
+;;           (lambda ()
+;;             (flycheck-mode t)
+;;             (setq flycheck-checker 'perl-project-libs)))
+
+;; 要carton
+(defun run-perl-test ()
+  (interactive)
+  (compile (format "cd %s; carton exec -- prove -lvr %s" (vc-git-root default-directory) (buffer-file-name (current-buffer)))))
+

--- a/.emacs.d/inits/40-perl.el
+++ b/.emacs.d/inits/40-perl.el
@@ -7,7 +7,8 @@
 (setq auto-mode-alist (cons '("\\.t$" . cperl-mode) auto-mode-alist))
 (setq auto-mode-alist (cons '("\\.cgi$" . cperl-mode) auto-mode-alist))
 (setq auto-mode-alist (cons '("\\.psgi$" . cperl-mode) auto-mode-alist))
-(setq auto-mode-alist (cons '("cpanfile$" . cperl-mode) auto-mode-alist))
+;; `Unquoted string "requires" may clash with future reserved word` とかいうエラーがcpanfileで出るので一時止める
+;; (setq auto-mode-alist (cons '("cpanfile$" . cperl-mode) auto-mode-alist))
 
 (setq cperl-indent-level 4
       cperl-continued-statement-offset 4
@@ -25,25 +26,27 @@
                (setq tab-width nil))))
 
 ;; flycheck settings
+(add-hook 'cperl-mode-hook 'flycheck-mode)
 
 ;; disable my module error
+;; 要Project::Libs
 ;; http://m0t0k1ch1st0ry.com/blog/2014/07/07/flycheck/
-;; (flycheck-define-checker perl-project-libs
-;;   "A perl syntax checker."
-;;   :command ("perl"
-;;             "-MProject::Libs lib_dirs => [qw(local/lib/perl5)]"
-;;             "-wc"
-;;             source-inplace)
-;;   :error-patterns ((error line-start
-;;                           (minimal-match (message))
-;;                           " at " (file-name) " line " line
-;;                           (or "." (and ", " (zero-or-more not-newline)))
-;;                           line-end))
-;;   :modes (cperl-mode))
-;; (add-hook 'cperl-mode-hook
-;;           (lambda ()
-;;             (flycheck-mode t)
-;;             (setq flycheck-checker 'perl-project-libs)))
+(flycheck-define-checker perl-project-libs
+  "A perl syntax checker."
+  :command ("perl"
+            "-MProject::Libs lib_dirs => [qw(local/lib/perl5)]"
+            "-wc"
+            source-inplace)
+  :error-patterns ((error line-start
+                          (minimal-match (message))
+                          " at " (file-name) " line " line
+                          (or "." (and ", " (zero-or-more not-newline)))
+                          line-end))
+  :modes (cperl-mode))
+(add-hook 'cperl-mode-hook
+          (lambda ()
+            (flycheck-mode t)
+            (setq flycheck-checker 'perl-project-libs)))
 
 ;; 要carton
 (defun run-perl-test ()

--- a/.emacs.d/snippets/cperl-mode/data_printer
+++ b/.emacs.d/snippets/cperl-mode/data_printer
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# key: data_printer
+# name: data_priter
+# binding: C-c C-c d
+# --
+use DDP;
+
+p $0;

--- a/.emacs.d/snippets/cperl-mode/package
+++ b/.emacs.d/snippets/cperl-mode/package
@@ -1,0 +1,14 @@
+# -*- mode: snippet -*-
+# key: package
+# name: package
+# binding: C-c C-c C-p
+# --
+package ${1:packagename};
+
+use strict;
+use warnings;
+use utf8;
+
+$0
+
+1;

--- a/.emacs.d/snippets/cperl-mode/subtest
+++ b/.emacs.d/snippets/cperl-mode/subtest
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# key: subtest
+# name: subtest
+# binding: C-c C-c t
+# --
+subtest '$1' => sub {
+    `yas/selected-text`$0
+};


### PR DESCRIPTION
# 改善したこと
- `MyProject/lib` 以下のモジュールのflycheckエラーを出さないようにした
- proveコマンドをemacsから叩くようにした
- yasnippetの導入
# まだ直っていないこと
- cpanfileでflycheckのエラーが出まくる
  - 一旦cpanfileでcperl-modeを有効にしないようにしている
# 他改善出来そうなこと
- perldocをhelmで見れると便利そう。[helm-perldoc](https://github.com/syohex/emacs-helm-perldoc)というのがあったけど上手く導入できなかったから今回は見送り
