### PR TITLE
Temporary disable running markdown-mdl by flycheck

### DIFF
--- a/.emacs.d/inits/40-markdown.el
+++ b/.emacs.d/inits/40-markdown.el
@@ -3,3 +3,10 @@
 
 (add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode))
 (add-to-list 'auto-mode-alist '("README\\.md\\'" . gfm-mode))
+
+;; markdown-mdlのlintを取り敢えずoff
+(add-hook 'markdown-mode-hook
+          '(lambda ()
+             (setq flycheck-disabled-checkers '(markdown-mdl))
+             (flycheck-mode 1)))
+


### PR DESCRIPTION
一時的にflycheckによるmarkdown-mdlの実行を無効にする.
[参照](http://www.flycheck.org/en/latest/languages.html#markdown)

後で `mdl` がインストールされているかどうかの確認を行う設定に変える.